### PR TITLE
Fix commandExecutor interface mismatch

### DIFF
--- a/app/code/Magento/Payment/Model/Method/Adapter.php
+++ b/app/code/Magento/Payment/Model/Method/Adapter.php
@@ -507,12 +507,13 @@ class Adapter implements MethodInterface
             return null;
         }
 
+        $payment = $arguments['payment'];
         if (isset($arguments['payment'])) {
             $arguments['payment'] = $this->paymentDataObjectFactory->create($arguments['payment']);
         }
 
         if ($this->commandExecutor !== null) {
-            return $this->commandExecutor->executeByCode($commandCode, $arguments);
+            return $this->commandExecutor->executeByCode($commandCode, $payment, $arguments);
         }
 
         if ($this->commandPool === null) {


### PR DESCRIPTION
executeByCode function is executed with 2 arguments here, but the interface of the commandExecutor object(CommandManagerInterface) accepts 3 arguments, 2nd argument should be an object supporting InfoInterface interface, which is passed as $arguments['payment'].
